### PR TITLE
Do not automatically load migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### Unreleased
+- [#3](https://github.com/westonganger/pairer/pull/3) - Do not automatically load migrations and instead require an explicit migration install step
+
 ### v1.0.0
 - Release to Rubygems
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ Each organization has many boards. Within each board you can create people and r
 
 Developed as a Rails engine. So you can add to any existing app or create a brand new app with the functionality.
 
+First add the gem to your Gemfile
+
 ```ruby
 ### Gemfile
 gem 'pairer'
 ```
 
+Then install and run the database migrations
+
+```sh
+bundle install
+bundle exec rake pairer:install:migrations
+bundle exec rake db:migrate
+```
 
 #### Option A: Mount to a path
 

--- a/lib/pairer/engine.rb
+++ b/lib/pairer/engine.rb
@@ -28,16 +28,6 @@ module Pairer
       end
     end
 
-    initializer "pairer.append_migrations" do |app|
-      ### Automatically load all migrations into main rails app
-      
-      if !app.root.to_s.match?(root.to_s)
-        config.paths["db/migrate"].expanded.each do |expanded_path|
-          app.config.paths["db/migrate"] << expanded_path
-        end
-      end
-    end
-
     initializer "pairer.load_static_assets" do |app|
       ### Expose static assets
       app.middleware.use ::ActionDispatch::Static, "#{root}/public"


### PR DESCRIPTION
Do not automatically load migrations and instead require an explicit migration install step.