### PR TITLE
Move render actioncable partial into view layout file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 - [View Diff](https://github.com/westonganger/pairer/compare/v1.2.0...master)
-- Nothing yet
+- [#19](https://github.com/westonganger/pairer/pull/19) - Move render actioncable partial into view layout file to fix issues with 404s and general board bugginess after updating the page content via Javascript (introduced in [#16](https://github.com/westonganger/pairer/pull/16))
 
 ### v1.2.0 - Nov 20, 2024
 - [View Diff](https://github.com/westonganger/pairer/compare/v1.1.0...v1.2.0)

--- a/app/views/layouts/pairer/application.html.slim
+++ b/app/views/layouts/pairer/application.html.slim
@@ -32,6 +32,9 @@ html
     = javascript_include_tag 'rails-ujs'
     = javascript_include_tag 'pairer/application'
 
+    - if controller.controller_path == "pairer/boards" && controller.action_name == "show"
+      = render "action_cable_script"
+
   body
     nav.navbar.navbar-inverse.navbar-fixed-top
       .container-fluid

--- a/app/views/pairer/boards/show.html.slim
+++ b/app/views/pairer/boards/show.html.slim
@@ -274,5 +274,3 @@ javascript:
     window.init_sortable_lists();
 
   });
-
-= render "action_cable_script"


### PR DESCRIPTION
Move render actioncable partial into view layout file to fix issues with 404s and general board bugginess after updating the page content via Javascript (introduced in [#16](https://github.com/westonganger/pairer/pull/16))
